### PR TITLE
fix(mac): 全新环境下创建 configLibrary entry

### DIFF
--- a/backend/registry.py
+++ b/backend/registry.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import uuid
 from typing import Optional
 
 from backend.model_alias import all_provider_model_entries, desktop_model_entries
@@ -623,7 +624,14 @@ def _mac_apply_library_config(
     if not ok:
         return {"success": False, "message": f"configLibrary 元数据读取失败: {message}"}
     if not paths:
-        return {"success": True, "message": "configLibrary 不存在，无需写入"}
+        library_dir = _mac_config_library_dir_path()
+        os.makedirs(library_dir, exist_ok=True)
+        entry_id = str(uuid.uuid4())
+        meta = {"appliedId": entry_id}
+        ok, message = _mac_write_json_file(_mac_config_library_meta_path(), meta)
+        if not ok:
+            return {"success": False, "message": f"configLibrary 元数据写入失败: {message}"}
+        paths = [_mac_config_library_entry_path(entry_id)]
 
     expected = _mac_json_enterprise_config(
         base_url,

--- a/tests/test_macos_config_library.py
+++ b/tests/test_macos_config_library.py
@@ -1,0 +1,44 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from backend import registry
+
+
+class MacosConfigLibraryTests(unittest.TestCase):
+    def test_apply_config_creates_config_library_entry_when_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            json_path = os.path.join(temp_dir, "Claude-3p", "claude_desktop_config.json")
+            library_dir = os.path.join(os.path.dirname(json_path), "configLibrary")
+
+            with patch.object(registry, "MAC_3P_CONFIG", json_path):
+                with patch("backend.registry._mac_apply_plist_config", return_value={"success": True}):
+                    result = registry._mac_apply_config(
+                        "http://127.0.0.1:18080",
+                        gateway_api_key="secret-value",
+                        inference_models='[{"name":"model-a","displayName":"Model A"},{"name":"model-b","supports1m":true}]',
+                        auth_scheme="x-api-key",
+                        gateway_headers='["x-api-key: secret-value"]',
+                    )
+
+            self.assertTrue(result["success"])
+            with open(os.path.join(library_dir, "_meta.json"), encoding="utf-8") as handle:
+                meta = json.load(handle)
+            entry_id = meta["appliedId"]
+            self.assertTrue(entry_id)
+            with open(os.path.join(library_dir, f"{entry_id}.json"), encoding="utf-8") as handle:
+                saved = json.load(handle)
+
+        self.assertEqual(saved["inferenceProvider"], "gateway")
+        self.assertEqual(saved["inferenceGatewayBaseUrl"], "http://127.0.0.1:18080")
+        self.assertEqual(saved["inferenceGatewayApiKey"], "secret-value")
+        self.assertEqual(saved["inferenceGatewayAuthScheme"], "x-api-key")
+        self.assertEqual(saved["inferenceGatewayHeaders"], ["x-api-key: secret-value"])
+        self.assertEqual(saved["inferenceModels"], ["model-a", "model-b"])
+        self.assertIs(saved["isClaudeCodeForDesktopEnabled"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

在 macOS 全新环境里，Claude Desktop 的 `configLibrary` 目录可能还不存在。原来的 `_mac_apply_library_config()` 在找不到任何 config library entry 时会直接返回成功，但实际上没有写入任何 3P 配置，导致点击 Apply 后 Claude Desktop 仍可能继续走官方配置。

## 改动

- 当 `configLibrary` 没有可写入的 entry 时，主动创建 `configLibrary` 目录。
- 生成新的 UUID 作为 active entry id。
- 写入 `_meta.json`，设置 `appliedId`。
- 使用现有的 gateway 配置写入逻辑创建初始 entry。
- 新增测试覆盖全新 `configLibrary` 缺失时的写入行为。

## 测试

已通过：

```bash
.venv-intel/bin/python -m unittest tests.test_macos_config_library tests.test_provider_config_and_proxy.ProviderConfigTests.test_macos_apply_config_writes_active_config_library_entry
```

另外也尝试跑了完整 unittest。和本 PR 相关的 macOS configLibrary 测试均通过；完整测试在本机 macOS/Python 3.13 下仍有两个既有 Windows single-instance 测试失败，原因是 macOS 上没有 `ctypes.windll`。