### PR TITLE
ci: 添加 Intel macOS x64 release 构建

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,91 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build_macos_intel:
+    name: Build macOS x64
+    runs-on: macos-15-intel
+    needs: prepare
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build macOS assets
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          arch="$(uname -m)"
+          if [[ "$arch" != "x86_64" ]]; then
+            echo "Expected macOS x86_64 runner, got: $arch" >&2
+            exit 1
+          fi
+
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
+          echo "RELEASE_ARCH=x64" >> "$GITHUB_ENV"
+          CCDS_VERSION="$RELEASE_VERSION" ./macos/build-macos.sh
+
+      - name: Smoke test macOS app bundle
+        shell: bash
+        run: |
+          app_exe="dist/mac/CC Desktop Switch.app/Contents/MacOS/CC-Desktop-Switch"
+          if [[ ! -x "$app_exe" ]]; then
+            echo "App executable not found: $app_exe" >&2
+            exit 1
+          fi
+
+          export HOME="$RUNNER_TEMP/ccds-home"
+          mkdir -p "$HOME"
+          "$app_exe" --server-only --port 19081 > "$RUNNER_TEMP/ccds-macos-smoke.log" 2>&1 &
+          app_pid=$!
+          cleanup() {
+            kill "$app_pid" 2>/dev/null || true
+            wait "$app_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          ok=0
+          for _ in {1..60}; do
+            if curl -fsS "http://127.0.0.1:19081/api/ready" >/dev/null; then
+              ok=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [[ "$ok" != "1" ]]; then
+            cat "$RUNNER_TEMP/ccds-macos-smoke.log" >&2
+            exit 1
+          fi
+
+      - name: Verify macOS packages
+        shell: bash
+        run: |
+          pkg="dist/mac/CC-Desktop-Switch-v${RELEASE_VERSION}-macOS-x64.pkg"
+          dmg="dist/mac/CC-Desktop-Switch-v${RELEASE_VERSION}-macOS-x64.dmg"
+
+          test -f "$pkg"
+          test -f "$dmg"
+          pkgutil --expand "$pkg" "$RUNNER_TEMP/pkg-expanded"
+          hdiutil verify "$dmg"
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-x64
+          path: |
+            dist/mac/CC-Desktop-Switch-v${{ needs.prepare.outputs.version }}-macOS-x64.pkg
+            dist/mac/CC-Desktop-Switch-v${{ needs.prepare.outputs.version }}-macOS-x64.dmg
+          if-no-files-found: error
+          retention-days: 7
+
   publish_release:
     name: Publish release
     runs-on: windows-latest
@@ -238,6 +323,7 @@ jobs:
       - prepare
       - build_windows
       - build_macos
+      - build_macos_intel
 
     steps:
       - name: Checkout
@@ -265,7 +351,7 @@ jobs:
             "-Version", $env:RELEASE_VERSION,
             "-StagingDir", "release-staging",
             "-Repository", $env:GITHUB_REPOSITORY,
-            "-RequiredPlatforms", "windows-x64", "macos-arm64"
+            "-RequiredPlatforms", "windows-x64,macos-arm64,macos-x64"
           )
           if (Test-Path -LiteralPath $notesPath) {
             $args += @("-NotesFile", $notesPath)
@@ -318,8 +404,13 @@ jobs:
             Set-Content -LiteralPath $notesFile -Value "Release for CC Desktop Switch v$env:RELEASE_VERSION." -Encoding utf8
           }
 
+          $oldEAP = $ErrorActionPreference
+          $ErrorActionPreference = "SilentlyContinue"
           $isDraft = gh release view $tag --repo $env:GITHUB_REPOSITORY --json isDraft --jq ".isDraft" 2>$null
-          if ($LASTEXITCODE -eq 0) {
+          $viewExitCode = $LASTEXITCODE
+          $ErrorActionPreference = $oldEAP
+
+          if ($viewExitCode -eq 0) {
             if ($isDraft.Trim() -ne "true") {
               throw "Release $tag already exists and is not a draft."
             }
@@ -328,8 +419,12 @@ jobs:
             Invoke-Gh release create $tag --repo $env:GITHUB_REPOSITORY --draft --title "CC Desktop Switch $tag" --notes-file $notesFile --verify-tag
           }
 
+          $ErrorActionPreference = "SilentlyContinue"
           $existingAssetsText = gh release view $tag --repo $env:GITHUB_REPOSITORY --json assets --jq ".assets[].name" 2>$null
-          if ($LASTEXITCODE -eq 0) {
+          $assetsExitCode = $LASTEXITCODE
+          $ErrorActionPreference = $oldEAP
+
+          if ($assetsExitCode -eq 0) {
             $existingAssets = $existingAssetsText -split "\r?\n"
             foreach ($asset in $existingAssets) {
               if ($asset) {

--- a/scripts/New-Release.ps1
+++ b/scripts/New-Release.ps1
@@ -87,7 +87,9 @@ function Get-Makensis {
     if ($cmd) { return $cmd.Source }
     $candidates = @(
         "C:\Program Files (x86)\NSIS\makensis.exe",
-        "C:\Program Files\NSIS\makensis.exe"
+        "C:\Program Files\NSIS\makensis.exe",
+        "C:\ProgramData\chocolatey\bin\makensis.exe",
+        "C:\ProgramData\chocolatey\lib\nsis\tools\NSIS\makensis.exe"
     )
     foreach ($candidate in $candidates) {
         if (Test-Path -LiteralPath $candidate) { return $candidate }

--- a/scripts/New-ReleaseManifest.ps1
+++ b/scripts/New-ReleaseManifest.ps1
@@ -4,9 +4,14 @@ param(
     [string]$Repository = $env:GITHUB_REPOSITORY,
     [string]$Notes,
     [string]$NotesFile,
-    [string[]]$RequiredPlatforms = @("windows-x64", "macos-arm64"),
+    [string[]]$RequiredPlatforms = @("windows-x64", "macos-arm64", "macos-x64"),
     [string]$KeyDir
 )
+
+# When invoked via powershell -File, comma-separated strings arrive as a single array element.
+if ($RequiredPlatforms.Count -eq 1 -and $RequiredPlatforms[0] -match ",") {
+    $RequiredPlatforms = $RequiredPlatforms[0] -split ","
+}
 
 $ErrorActionPreference = "Stop"
 
@@ -187,7 +192,9 @@ $requiredAssetNames = @(
     "CC-Desktop-Switch-v$Version-Windows-Portable.zip",
     "CC-Desktop-Switch-v$Version-Windows-Setup.exe",
     "CC-Desktop-Switch-v$Version-macOS-arm64.pkg",
-    "CC-Desktop-Switch-v$Version-macOS-arm64.dmg"
+    "CC-Desktop-Switch-v$Version-macOS-arm64.dmg",
+    "CC-Desktop-Switch-v$Version-macOS-x64.pkg",
+    "CC-Desktop-Switch-v$Version-macOS-x64.dmg"
 )
 
 foreach ($assetName in $requiredAssetNames) {

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -1981,6 +1981,8 @@ class ReleaseManifestTests(unittest.TestCase):
         for name in (
             f"CC-Desktop-Switch-v{self.VERSION}-macOS-arm64.pkg",
             f"CC-Desktop-Switch-v{self.VERSION}-macOS-arm64.dmg",
+            f"CC-Desktop-Switch-v{self.VERSION}-macOS-x64.pkg",
+            f"CC-Desktop-Switch-v{self.VERSION}-macOS-x64.dmg",
         ):
             self._touch_asset(name)
 
@@ -2031,6 +2033,7 @@ class ReleaseManifestTests(unittest.TestCase):
         self.assertEqual(latest["version"], self.VERSION)
         self.assertIn("windows-x64", latest["platforms"])
         self.assertIn("macos-arm64", latest["platforms"])
+        self.assertIn("macos-x64", latest["platforms"])
         self.assertTrue((self.staging / "latest.json.sha256").exists())
         self.assertTrue((self.staging / "latest.json.sig").exists())
         self.assertTrue((self.staging / "CC-Desktop-Switch-release-public.pem").exists())
@@ -2040,6 +2043,8 @@ class ReleaseManifestTests(unittest.TestCase):
             f"CC-Desktop-Switch-v{self.VERSION}-Windows-Setup.exe",
             f"CC-Desktop-Switch-v{self.VERSION}-macOS-arm64.pkg",
             f"CC-Desktop-Switch-v{self.VERSION}-macOS-arm64.dmg",
+            f"CC-Desktop-Switch-v{self.VERSION}-macOS-x64.pkg",
+            f"CC-Desktop-Switch-v{self.VERSION}-macOS-x64.dmg",
         ):
             self.assertTrue((self.staging / f"{asset}.sha256").exists(), asset)
             self.assertTrue((self.staging / f"{asset}.sig").exists(), asset)
@@ -2050,7 +2055,11 @@ class ReleaseManifestTests(unittest.TestCase):
         installer = (self.root / "installer.nsi").read_text(encoding="utf-8")
 
         self.assertIn('tag_sha="$(git rev-list -n 1 "$tag")"', workflow)
-        self.assertGreaterEqual(workflow.count("ref: ${{ needs.prepare.outputs.tag }}"), 3)
+        self.assertGreaterEqual(workflow.count("ref: ${{ needs.prepare.outputs.tag }}"), 4)
+        self.assertIn("build_macos_intel:", workflow)
+        self.assertIn("runs-on: macos-15-intel", workflow)
+        self.assertIn("macOS-x64.pkg", workflow)
+        self.assertIn("macOS-x64.dmg", workflow)
         self.assertIn("release delete-asset", workflow)
         self.assertIn('"/DPRODUCT_VERSION=$Version"', new_release)
         self.assertIn("!ifndef PRODUCT_VERSION", installer)


### PR DESCRIPTION

## 背景

当前 release workflow 只产出 macOS arm64 包，Intel Mac 用户需要本地构建。这个 PR 单独补上 macOS x64 release 构建，并同步 release manifest 的 x64 资产校验。

## 改动

- 新增 `build_macos_intel` job，使用 `macos-15-intel` runner 构建 x64 `.pkg` 和 `.dmg`
- `publish_release` 等待 macOS x64 构建完成
- release manifest 默认要求 `macos-x64` 平台资产
- 修复 `powershell -File` 传递 `RequiredPlatforms` 时数组参数错位的问题
- 增加 Chocolatey 安装 NSIS 时的 `makensis.exe` 查找路径
- 补齐 release manifest 测试 staging，覆盖 `macOS-x64.pkg/dmg`

## 测试

本地已通过：

```bash
.venv-intel/bin/python -m unittest tests.test_provider_config_and_proxy.ReleaseManifestTests -v
git diff --check
```

GitHub Actions 已在 fork 分支 `fix/intel-macos-x64-release` 上手动触发并通过，包含：

- `Build Windows x64`
- `Build macOS arm64`
- `Build macOS x64`
- `Generate manifest and signatures`
- `Publish release`

截图：

<img width="2258" height="916" alt="2b3ebb16-b3e5-4d30-9061-07b46d76920d" src="https://github.com/user-attachments/assets/38269d18-3898-48bf-a9fb-2fe36859bd82" />

