### PR TITLE
fix(update): show Windows installer after download

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -63,7 +63,7 @@ def verify_admin_token(value: str) -> bool:
     return bool(value) and secrets.compare_digest(str(value), _admin_token)
 
 
-def _popen_hidden(command: list[str], *, detached: bool = False):
+def _popen_hidden(command: list[str], *, detached: bool = False, show_window: bool = False):
     """启动外部程序时避免 Windows 弹出黑色终端窗口。"""
     kwargs = {"close_fds": True}
     if detached:
@@ -71,10 +71,12 @@ def _popen_hidden(command: list[str], *, detached: bool = False):
         kwargs["stdout"] = subprocess.DEVNULL
         kwargs["stderr"] = subprocess.DEVNULL
     if sys.platform == "win32":
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        kwargs["startupinfo"] = startupinfo
-        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        creationflags = 0
+        if not show_window:
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            kwargs["startupinfo"] = startupinfo
+            creationflags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
         if detached:
             creationflags |= getattr(subprocess, "DETACHED_PROCESS", 0)
             creationflags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
@@ -137,7 +139,10 @@ def _launch_update_installer(installer_path: str, platform: str) -> bool:
         return _schedule_update_quit_for_install(quit_handler)
 
     command = updater.install_command(installer_path, platform)
-    _popen_hidden(command, detached=True)
+    if platform.startswith("windows-"):
+        _popen_hidden(command, detached=True, show_window=True)
+    else:
+        _popen_hidden(command, detached=True)
     return False
 
 

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -1900,7 +1900,11 @@ class AdminApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["installerStarted"])
-        popen.assert_called_once_with([r"C:\Temp\CC-Desktop-Switch-v1.0.11-Windows-Setup.exe"], detached=True)
+        popen.assert_called_once_with(
+            [r"C:\Temp\CC-Desktop-Switch-v1.0.11-Windows-Setup.exe"],
+            detached=True,
+            show_window=True,
+        )
 
     def test_update_install_opens_downloaded_macos_package(self):
         async def fake_download_update(url, current_version, platform="windows-x64", target_dir=None):


### PR DESCRIPTION
## Summary

修复 Windows 应用内更新下载完成后，安装器被隐藏启动的问题。这个问题对应 #12：用户看到应用退出或被安装器关闭，但安装器窗口没有弹出。

## Main changes

- 为 `_popen_hidden()` 增加 `show_window` 参数。
- Windows 更新安装器启动时不再设置隐藏窗口参数。
- macOS 的安装器打开逻辑保持不变。
- 更新测试，确认 Windows 安装器以可见方式启动。

## Affected modules

- `backend/main.py`
- `tests/test_provider_config_and_proxy.py`

## How to test

已在本地通过：

```bash
python -m unittest tests.test_provider_config_and_proxy.AdminApiTests.test_update_install_launches_downloaded_installer tests.test_provider_config_and_proxy.AdminApiTests.test_update_install_opens_downloaded_macos_package tests.test_provider_config_and_proxy.AdminApiTests.test_update_install_waits_for_macos_quit_before_opening_package -v
python -m compileall -q backend main.py tests
python -m unittest discover -s tests -v
node --check frontend/js/api.js
node --check frontend/js/app.js
node --check frontend/js/i18n.js
git diff --check
```

## Risks and rollback

风险较低。改动只影响 Windows 更新安装器启动窗口是否可见，不改变下载、校验、版本判断或 macOS 更新流程。若出现异常，可以回滚该提交，恢复之前的隐藏启动行为。

## Follow-up work

- 合并后可纳入 `v1.0.21` 小版本。
- 发布后回复 #12，请用户验证新版本更新安装器是否正常弹出。