### PR TITLE
chore(release): prepare v1.0.21

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -16,7 +16,7 @@ BACKUP_DIR = os.path.join(CONFIG_DIR, "backups")
 DEFAULT_UPDATE_URL = "https://github.com/lonr-6/cc-desktop-switch/releases/latest/download/latest.json"
 
 DEFAULT_CONFIG = {
-    "version": "1.0.20",
+    "version": "1.0.21",
     "activeProvider": None,
     "gatewayApiKey": None,
     "providers": [],

--- a/backend/main.py
+++ b/backend/main.py
@@ -745,7 +745,7 @@ async def _detect_local_proxy() -> Optional[str]:
 
 def create_admin_app() -> FastAPI:
     """创建管理后台 FastAPI 应用"""
-    app = FastAPI(title="CC Desktop Switch Admin", version="1.0.20")
+    app = FastAPI(title="CC Desktop Switch Admin", version="1.0.21")
 
     @app.middleware("http")
     async def require_local_admin_auth(request: Request, call_next):

--- a/backend/proxy.py
+++ b/backend/proxy.py
@@ -770,7 +770,7 @@ def _get_http_proxy() -> Optional[str]:
 
 def create_proxy_app() -> FastAPI:
     """创建代理 FastAPI 应用"""
-    app = FastAPI(title="CC Desktop Switch Proxy", version="1.0.20")
+    app = FastAPI(title="CC Desktop Switch Proxy", version="1.0.21")
 
     def upstream_error_status(result: dict) -> int:
         """把上游错误转换成 HTTP 错误状态，避免桌面端按成功响应解析。"""

--- a/build.bat
+++ b/build.bat
@@ -5,7 +5,7 @@ chcp 65001 >nul
 :MENU
 cls
 echo ========================================
-echo    CC Desktop Switch v1.0.20 - 构建工具
+echo    CC Desktop Switch v1.0.21 - 构建工具
 echo ========================================
 echo.
 echo  请选择打包方式：

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@
   <a href="CHANGELOG.md">Changelog</a>
 </p>
 
+## v1.0.21
+
+Release notes: [docs/release-notes-v1.0.21.md](release-notes-v1.0.21.md)
+
+- Fixed macOS fresh-environment writes by creating a `configLibrary` entry when none exists.
+- Added Intel macOS x64 release assets alongside Windows x64 and macOS arm64.
+- Added safe custom Claude route mappings that expose only `claude-*` model names to Claude Desktop.
+- Fixed Windows in-app update installs so the downloaded installer opens visibly.
+- Kept #7, #9, and #10 open for follow-up; this patch release does not claim those issues are fixed.
+
 ## v1.0.20
 
 Release notes: [docs/release-notes-v1.0.20.md](release-notes-v1.0.20.md)

--- a/docs/release-notes-v1.0.21.md
+++ b/docs/release-notes-v1.0.21.md
@@ -1,0 +1,74 @@
+# CC Desktop Switch v1.0.21
+
+<p align="center">
+  <a href="#english">English</a> |
+  <a href="#simplified-chinese">简体中文</a>
+</p>
+
+<a id="english"></a>
+
+## English
+
+This is a small patch release for the current stable Python line. It publishes the fixes and improvements already merged into `main` and does not change the main provider workflow.
+
+### Highlights
+
+- **macOS fresh installs write Desktop configuration correctly**
+  - When Claude Desktop has no `configLibrary` entry yet, CC Desktop Switch now creates one before writing the active gateway configuration.
+  - This avoids a misleading successful apply on a fresh macOS environment where no Desktop config was actually written.
+
+- **Intel Mac release assets are now included**
+  - The release workflow now builds macOS x64 `.pkg` and `.dmg` assets in addition to Windows x64 and macOS arm64.
+  - `latest.json` now includes `windows-x64`, `macos-arm64`, and `macos-x64` platforms.
+
+- **Safe custom Claude model routes**
+  - Provider settings can now include custom Claude route mappings.
+  - Only `claude-*` route names are exposed to Claude Desktop, while the real upstream model IDs stay inside the local gateway mapping.
+  - This keeps compatibility with newer Claude Desktop versions that reject raw third-party model IDs in `inferenceModels`.
+
+- **Windows in-app update installer is visible**
+  - Fixed a Windows update flow where the installer could be launched with hidden window flags after download.
+  - The downloaded Windows installer now opens visibly so users can complete the install.
+
+### Not Included
+
+- #7, #9, and #10 remain open for follow-up.
+- This release does not claim to fix every OpenAI/new-api relay variant, OpenCode Max compatibility, or the reported macOS DeepSeek 1M status issue.
+
+### Upgrade Notes
+
+No user configuration migration is required. After updating, re-apply the active provider to Claude Desktop if your Desktop configuration was written by an older version, then fully restart Claude Desktop.
+
+<a id="simplified-chinese"></a>
+
+## 简体中文
+
+这是当前 Python 稳定线的小版本更新，只发布已经合并进 `main` 的修复和改进，不改变主要 provider 使用流程。
+
+### 主要变化
+
+- **macOS 全新环境可以正确写入桌面版配置**
+  - 当 Claude Desktop 还没有 `configLibrary` entry 时，CC Desktop Switch 会先创建 entry，再写入当前本机 gateway 配置。
+  - 这可以避免全新 macOS 环境里显示应用成功，但实际上没有写入桌面版配置的问题。
+
+- **补齐 Intel Mac 发布资产**
+  - Release workflow 现在会额外构建 macOS x64 `.pkg` 和 `.dmg`。
+  - `latest.json` 会同时包含 `windows-x64`、`macos-arm64` 和 `macos-x64`。
+
+- **支持安全的自定义 Claude 模型 route**
+  - Provider 设置里可以添加自定义 Claude route 映射。
+  - 只会把 `claude-*` route 暴露给 Claude Desktop，真实上游模型 ID 仍只保留在本机 gateway 内部。
+  - 这样可以兼容新版 Claude Desktop 对 `inferenceModels` 的模型名校验。
+
+- **Windows 应用内更新安装器会正常弹出**
+  - 修复 Windows 下载更新后，安装器被隐藏窗口参数启动的问题。
+  - 下载完成后，Windows 安装器会以可见窗口打开，用户可以继续完成安装。
+
+### 未包含内容
+
+- #7、#9、#10 继续保持打开，后续单独跟进。
+- 本版本不声称已经修复所有 OpenAI/new-api 中转差异、OpenCode Max 兼容性或 macOS DeepSeek 1M 状态提示问题。
+
+### 升级说明
+
+不需要迁移用户配置。升级后，如果 Claude Desktop 配置来自旧版本，建议重新对当前 provider 执行“一键应用到 Claude 桌面版”，然后完整重启 Claude Desktop。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -415,7 +415,7 @@
 
         <article class="panel about-panel">
           <h2 data-i18n="settings.about">关于</h2>
-          <div class="about-row"><span data-i18n="settings.version">版本</span><strong>1.0.20</strong></div>
+          <div class="about-row"><span data-i18n="settings.version">版本</span><strong>1.0.21</strong></div>
           <div class="about-row"><span data-i18n="settings.license">许可证</span><strong>MIT License</strong></div>
           <div class="about-row"><span data-i18n="settings.checkUpdate">检查更新</span><span class="settings-actions inline-actions"><button class="btn btn-outline-primary btn-sm" type="button" data-action="check-update"><i class="bi bi-cloud-arrow-down"></i><span data-i18n="settings.checkUpdate">检查更新</span></button><button class="btn btn-primary btn-sm" id="settingsInstallUpdate" type="button" data-action="install-update" hidden><i class="bi bi-download"></i><span data-i18n="settings.installUpdate">下载并安装</span></button></span></div>
           <p class="update-status" id="updateStatus"></p>

--- a/installer.nsi
+++ b/installer.nsi
@@ -4,12 +4,12 @@
 ;  Prerequisites:
 ;     1. Install NSIS 3.0+
 ;     2. Run: makensis installer.nsi
-;     3. Output: CC-Desktop-Switch-Setup-1.0.20.exe
+;     3. Output: CC-Desktop-Switch-Setup-1.0.21.exe
 ;============================================
 
 !define PRODUCT_NAME "CC Desktop Switch"
 !ifndef PRODUCT_VERSION
-  !define PRODUCT_VERSION "1.0.20"
+  !define PRODUCT_VERSION "1.0.21"
 !endif
 !define PRODUCT_PUBLISHER "CC Desktop Switch"
 !define PRODUCT_DIR "$PROGRAMFILES64\CC-Desktop-Switch"

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from backend import registry
 
 
 APP_NAME = "CC Desktop Switch"
-APP_VERSION = "1.0.20"
+APP_VERSION = "1.0.21"
 TRAY_OPEN_LABEL = "打开 CC Desktop Switch"
 TRAY_QUIT_LABEL = "退出"
 _macos_app_delegate = None

--- a/scripts/New-Release.ps1
+++ b/scripts/New-Release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.0.20",
+    [string]$Version = "1.0.21",
     [string]$OutputDir = "release",
     [switch]$Build,
     [switch]$TryInstaller,

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -1974,7 +1974,7 @@ class AdminApiTests(unittest.TestCase):
 
 
 class ReleaseManifestTests(unittest.TestCase):
-    VERSION = "1.0.20"
+    VERSION = "1.0.21"
 
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary

准备 `v1.0.21` 小版本发布。本 PR 只做版本号和发布说明更新，不改变主线功能逻辑。

## Main changes

- 将应用版本统一从 `1.0.20` 更新到 `1.0.21`。
- 新增 `docs/release-notes-v1.0.21.md`。
- 更新 `docs/CHANGELOG.md`。
- Release notes 明确本次只包含已合并的 #13/#14/#15/#16，不声称修复 #7/#9/#10。

## Affected modules

- 应用版本显示和后端版本声明
- Windows installer / build script 默认版本
- Release notes / changelog
- Release manifest 测试版本常量

## How to test

已在本地通过：

```bash
python -m compileall -q backend main.py tests
python -m unittest discover -s tests -v
node --check frontend/js/api.js
node --check frontend/js/app.js
node --check frontend/js/i18n.js
git diff --check
rg 1.0.20 backend main.py frontend installer.nsi build.bat scripts tests docs README.md README.zh-CN.md README.ja.md
```

`1.0.20` 只剩历史 changelog / release notes 引用。

## Risks and rollback

风险低。本 PR 不改运行逻辑，只改发布版本和说明。如果发布前发现问题，可以直接关闭该 PR 或回滚该提交，不影响已发布的 `v1.0.20`。

## Follow-up work

- 合并后触发 `Release` workflow，参数 `version=1.0.21`。
- 发布成功后验证 `latest.json` 和所有 Windows/macOS 资产。
- 发布成功后回复 #12，让用户验证应用内更新安装器是否正常弹出。