### PR TITLE
refactor(config): move builtin provider presets to data files with schema validation

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,14 +1,15 @@
 """配置管理 - JSON 配置文件读写"""
 
+import copy
 import json
 import os
 import secrets
 import shutil
-import copy
 from datetime import datetime
 from typing import Optional
 
 from backend.model_alias import model_mappings_with_legacy_aliases, normalize_model_mappings
+from backend.preset_loader import load_builtin_presets
 
 CONFIG_DIR = os.path.expanduser("~/.cc-desktop-switch")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
@@ -32,240 +33,6 @@ DEFAULT_CONFIG = {
         "upstreamProxyEnabled": False,
     },
 }
-
-BUILTIN_PRESETS = [
-    {
-        "id": "deepseek",
-        "name": "DeepSeek",
-        "baseUrl": "https://api.deepseek.com/anthropic",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "deepseek-v4-pro",
-            "haiku": "deepseek-v4-flash",
-            "opus": "deepseek-v4-pro",
-            "default": "deepseek-v4-pro",
-        },
-        "modelOptions": {
-            "deepseek_1m": {
-                "label": "解锁 1M 上下文",
-                "description": "用于 Claude Code/长上下文场景。开启后 Sonnet、Opus 和默认模型使用 deepseek-v4-pro[1m]，Haiku/Flash 也会标记 1M 能力。",
-                "models": {
-                    "sonnet": "deepseek-v4-pro[1m]",
-                    "haiku": "deepseek-v4-flash",
-                    "opus": "deepseek-v4-pro[1m]",
-                    "default": "deepseek-v4-pro[1m]",
-                },
-                "modelCapabilities": {
-                    "deepseek-v4-pro[1m]": {"supports1m": True},
-                    "deepseek-v4-flash": {"supports1m": True},
-                },
-            }
-        },
-        "requestOptions": {},
-        "requestOptionPresets": {
-            "deepseek_max_effort": {
-                "label": "DeepSeek Max 思维",
-                "description": "Low：更快更省，适合简单任务。\nMedium：速度和效果平衡，适合日常使用。\nHigh：更认真思考，适合复杂代码和排错。\n勾选后：本工具会按 DeepSeek Max 转发；未勾选则使用 Claude 当前默认配置。",
-                "requestOptions": {
-                    "anthropic": {
-                        "thinking": {"type": "enabled"},
-                        "output_config": {"effort": "max"},
-                    }
-                },
-            }
-        },
-        "extraHeaders": {"x-api-key": "{apiKey}"},
-        "isBuiltin": True,
-    },
-    {
-        "id": "third-party",
-        "name": "第三方模型",
-        "baseUrl": "",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "",
-            "haiku": "",
-            "opus": "",
-            "default": "",
-        },
-        "modelOptions": {
-            "third_party_1m": {
-                "label": "解锁 1M 上下文",
-                "description": "用于 Claude Code/长上下文场景。开启后 Sonnet、Opus 和默认模型使用支持 1M 上下文的模型。",
-                "models": {
-                    "sonnet": "",
-                    "haiku": "",
-                    "opus": "",
-                    "default": "",
-                },
-                "modelCapabilities": {},
-            }
-        },
-        "requestOptions": {},
-        "requestOptionPresets": {
-            "third_party_max_effort": {
-                "label": "Max 思维",
-                "description": "Low：更快更省，适合简单任务。\nMedium：速度和效果平衡，适合日常使用。\nHigh：更认真思考，适合复杂代码和排错。\n勾选后：本工具会按 Max 思维转发；未勾选则使用 Claude 当前默认配置。",
-                "requestOptions": {
-                    "anthropic": {
-                        "thinking": {"type": "enabled"},
-                        "output_config": {"effort": "max"},
-                    }
-                },
-            }
-        },
-        "isBuiltin": True,
-    },
-    {
-        "id": "kimi",
-        "name": "Kimi (月之暗面)",
-        "baseUrl": "https://api.moonshot.cn/anthropic",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "kimi-k2.6",
-            "haiku": "kimi-k2.6",
-            "opus": "kimi-k2.6",
-            "default": "kimi-k2.6",
-        },
-        "isBuiltin": True,
-    },
-    {
-        "id": "kimi-code",
-        "name": "Kimi Code",
-        "baseUrl": "https://api.kimi.com/coding",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "kimi-for-coding",
-            "haiku": "kimi-for-coding",
-            "opus": "kimi-for-coding",
-            "default": "kimi-for-coding",
-        },
-        "isBuiltin": True,
-    },
-    {
-        "id": "xiaomi-mimo-payg",
-        "name": "Xiaomi MiMo (Pay for Token)",
-        "baseUrl": "https://api.xiaomimimo.com/anthropic",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "",
-            "haiku": "",
-            "opus": "",
-            "default": "mimo-v2.5-pro",
-        },
-        "modelOptions": {
-            "mimo_1m": {
-                "label": "启用 MiMo 1M 上下文",
-                "description": "用于 Claude Code/长上下文场景。只会把已显式映射到 MiMo Pro 的 Claude 模型入口标记为 1M；Default 不会作为菜单项。",
-                "modelCapabilities": {
-                    "mimo-v2.5-pro": {"supports1m": True},
-                    "mimo-v2-pro": {"supports1m": True},
-                },
-            },
-        },
-        "modelCapabilities": {},
-        "isBuiltin": True,
-    },
-    {
-        "id": "xiaomi-mimo-token-plan",
-        "name": "Xiaomi MiMo (Token Plan)",
-        "baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "baseUrlOptions": [
-            {
-                "label": "中国集群",
-                "value": "https://token-plan-cn.xiaomimimo.com/anthropic",
-            },
-            {
-                "label": "新加坡集群",
-                "value": "https://token-plan-sgp.xiaomimimo.com/anthropic",
-            },
-            {
-                "label": "欧洲集群",
-                "value": "https://token-plan-ams.xiaomimimo.com/anthropic",
-            },
-        ],
-        "baseUrlHint": "请使用账号所属地区的 Base URL，若不清楚请访问 https://platform.xiaomimimo.com/console/plan-manage 获取专属Base URL。",
-        "models": {
-            "sonnet": "",
-            "haiku": "",
-            "opus": "",
-            "default": "mimo-v2.5-pro",
-        },
-        "modelOptions": {
-            "mimo_1m": {
-                "label": "启用 MiMo 1M 上下文",
-                "description": "用于 Claude Code/长上下文场景。只会把已显式映射到 MiMo Pro 的 Claude 模型入口标记为 1M；Default 不会作为菜单项。",
-                "modelCapabilities": {
-                    "mimo-v2.5-pro": {"supports1m": True},
-                    "mimo-v2-pro": {"supports1m": True},
-                },
-            },
-        },
-        "modelCapabilities": {},
-        "isBuiltin": True,
-    },
-    {
-        "id": "zhipu",
-        "name": "智谱 GLM",
-        "baseUrl": "https://open.bigmodel.cn/api/anthropic",
-        "authScheme": "x-api-key",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "glm-5.1",
-            "haiku": "glm-4.7",
-            "opus": "glm-5.1",
-            "default": "glm-5.1",
-        },
-        "isBuiltin": True,
-    },
-    {
-        "id": "bailian",
-        "name": "阿里云百炼",
-        "baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
-        "authScheme": "x-api-key",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "qwen3.6-plus",
-            "haiku": "qwen3.6-flash",
-            "opus": "qwen3.6-max-preview",
-            "default": "qwen3.6-plus",
-        },
-        "modelOptions": {
-            "qwen_1m": {
-                "label": "开启千问 1M 上下文",
-                "description": "阿里云文档确认 qwen3.6-plus / qwen3.6-flash 支持 1M。勾选后会把 1M 能力写入 Claude 桌面版；不勾选则按普通上下文显示。",
-                "modelCapabilities": {
-                    "qwen3.6-plus": {"supports1m": True},
-                    "qwen3.6-flash": {"supports1m": True},
-                },
-            }
-        },
-        "modelCapabilities": {},
-        "requestOptions": {},
-        "isBuiltin": True,
-    },
-    {
-        "id": "bailian-token-plan",
-        "name": "阿里云百炼 (Token Plan)",
-        "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
-        "authScheme": "bearer",
-        "apiFormat": "anthropic",
-        "models": {
-            "sonnet": "",
-            "haiku": "",
-            "opus": "",
-            "default": "qwen3.6-plus",
-        },
-        "isBuiltin": True,
-    },
-]
 
 
 def ensure_config_dir():
@@ -650,4 +417,4 @@ def update_settings(settings: dict) -> dict:
 
 def get_presets() -> list:
     """获取内置预设列表"""
-    return [_preset_with_legacy_model_aliases(preset) for preset in BUILTIN_PRESETS]
+    return [_preset_with_legacy_model_aliases(preset) for preset in load_builtin_presets()]

--- a/backend/preset_loader.py
+++ b/backend/preset_loader.py
@@ -1,0 +1,165 @@
+"""内置 provider 预设文件加载与 schema 校验。"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+PRESETS_DIR = Path(__file__).resolve().parent / "presets"
+PRESET_SCHEMA_FILE = PRESETS_DIR / "schema.json"
+
+
+def _read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _value_type_name(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+def _matches_type(value: Any, expected_type: str) -> bool:
+    checks = {
+        "array": lambda item: isinstance(item, list),
+        "boolean": lambda item: isinstance(item, bool),
+        "integer": lambda item: isinstance(item, int) and not isinstance(item, bool),
+        "number": lambda item: isinstance(item, (int, float)) and not isinstance(item, bool),
+        "object": lambda item: isinstance(item, dict),
+        "string": lambda item: isinstance(item, str),
+    }
+    checker = checks.get(str(expected_type or "").strip().lower())
+    return checker(value) if checker else True
+
+
+def _schema_path(path: str, key: str) -> str:
+    return f"{path}.{key}" if path != "$" else f"$.{key}"
+
+
+def _validate_schema(value: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+
+    expected_type = schema.get("type")
+    if isinstance(expected_type, str):
+        expected_types = [expected_type]
+    elif isinstance(expected_type, list):
+        expected_types = [item for item in expected_type if isinstance(item, str)]
+    else:
+        expected_types = []
+
+    if expected_types and not any(_matches_type(value, item) for item in expected_types):
+        expected_text = " or ".join(expected_types)
+        return [f"{path}: expected {expected_text}, got {_value_type_name(value)}"]
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']}, got {value!r}")
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and len(value) < min_length:
+            errors.append(f"{path}: expected length >= {min_length}, got {len(value)}")
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and not re.fullmatch(pattern, value):
+            errors.append(f"{path}: does not match pattern {pattern!r}")
+
+    if isinstance(value, dict):
+        required = schema.get("required")
+        if isinstance(required, list):
+            for key in required:
+                if isinstance(key, str) and key not in value:
+                    errors.append(f"{_schema_path(path, key)}: missing required field")
+
+        properties = schema.get("properties") if isinstance(schema.get("properties"), dict) else {}
+        additional = schema.get("additionalProperties", True)
+        for key, item in value.items():
+            child_path = _schema_path(path, str(key))
+            if key in properties:
+                errors.extend(_validate_schema(item, properties[key], child_path))
+                continue
+            if additional is True or additional is None:
+                continue
+            if additional is False:
+                errors.append(f"{child_path}: unexpected field")
+                continue
+            if isinstance(additional, dict):
+                errors.extend(_validate_schema(item, additional, child_path))
+
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                errors.extend(_validate_schema(item, item_schema, f"{path}[{index}]"))
+
+    return errors
+
+
+def _load_preset_schema() -> dict[str, Any]:
+    try:
+        payload = _read_json(PRESET_SCHEMA_FILE)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"内置 provider schema 加载失败: {PRESET_SCHEMA_FILE} ({exc})") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"内置 provider schema 必须是 JSON 对象: {PRESET_SCHEMA_FILE}")
+    return payload
+
+
+def load_builtin_presets() -> list[dict[str, Any]]:
+    """从 backend/presets 加载内置 provider 预设。"""
+    if not PRESETS_DIR.exists():
+        raise RuntimeError(f"内置 provider 预设目录不存在: {PRESETS_DIR}")
+
+    schema = _load_preset_schema()
+    preset_files = sorted(
+        path for path in PRESETS_DIR.glob("*.json")
+        if path.name != PRESET_SCHEMA_FILE.name
+    )
+    if not preset_files:
+        raise RuntimeError(f"未找到任何内置 provider 预设数据文件: {PRESETS_DIR}")
+
+    presets: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for path in preset_files:
+        try:
+            payload = _read_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("跳过内置 provider 预设 %s：读取失败：%s", path.name, exc)
+            continue
+
+        if not isinstance(payload, dict):
+            logger.warning("跳过内置 provider 预设 %s：顶层必须是 JSON 对象", path.name)
+            continue
+
+        errors = _validate_schema(payload, schema)
+        if errors:
+            logger.warning("跳过内置 provider 预设 %s：%s", path.name, "; ".join(errors[:5]))
+            continue
+
+        preset_id = str(payload.get("id") or "").strip()
+        if preset_id in seen_ids:
+            logger.warning("跳过内置 provider 预设 %s：重复的 id %s", path.name, preset_id)
+            continue
+        seen_ids.add(preset_id)
+        presets.append(payload)
+
+    if not presets:
+        raise RuntimeError(f"未加载到任何有效的内置 provider 预设: {PRESETS_DIR}")
+
+    return presets

--- a/backend/presets/01-deepseek.json
+++ b/backend/presets/01-deepseek.json
@@ -1,0 +1,54 @@
+{
+  "id": "deepseek",
+  "name": "DeepSeek",
+  "baseUrl": "https://api.deepseek.com/anthropic",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "deepseek-v4-pro",
+    "haiku": "deepseek-v4-flash",
+    "opus": "deepseek-v4-pro",
+    "default": "deepseek-v4-pro"
+  },
+  "modelOptions": {
+    "deepseek_1m": {
+      "label": "解锁 1M 上下文",
+      "description": "用于 Claude Code/长上下文场景。开启后 Sonnet、Opus 和默认模型使用 deepseek-v4-pro[1m]，Haiku/Flash 也会标记 1M 能力。",
+      "models": {
+        "sonnet": "deepseek-v4-pro[1m]",
+        "haiku": "deepseek-v4-flash",
+        "opus": "deepseek-v4-pro[1m]",
+        "default": "deepseek-v4-pro[1m]"
+      },
+      "modelCapabilities": {
+        "deepseek-v4-pro[1m]": {
+          "supports1m": true
+        },
+        "deepseek-v4-flash": {
+          "supports1m": true
+        }
+      }
+    }
+  },
+  "requestOptions": {},
+  "requestOptionPresets": {
+    "deepseek_max_effort": {
+      "label": "DeepSeek Max 思维",
+      "description": "Low：更快更省，适合简单任务。\nMedium：速度和效果平衡，适合日常使用。\nHigh：更认真思考，适合复杂代码和排错。\n勾选后：本工具会按 DeepSeek Max 转发；未勾选则使用 Claude 当前默认配置。",
+      "requestOptions": {
+        "anthropic": {
+          "thinking": {
+            "type": "enabled"
+          },
+          "output_config": {
+            "effort": "max"
+          }
+        }
+      }
+    }
+  },
+  "extraHeaders": {
+    "x-api-key": "{apiKey}"
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/02-third-party.json
+++ b/backend/presets/02-third-party.json
@@ -1,0 +1,44 @@
+{
+  "id": "third-party",
+  "name": "第三方模型",
+  "baseUrl": "",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "",
+    "haiku": "",
+    "opus": "",
+    "default": ""
+  },
+  "modelOptions": {
+    "third_party_1m": {
+      "label": "解锁 1M 上下文",
+      "description": "用于 Claude Code/长上下文场景。开启后 Sonnet、Opus 和默认模型使用支持 1M 上下文的模型。",
+      "models": {
+        "sonnet": "",
+        "haiku": "",
+        "opus": "",
+        "default": ""
+      },
+      "modelCapabilities": {}
+    }
+  },
+  "requestOptions": {},
+  "requestOptionPresets": {
+    "third_party_max_effort": {
+      "label": "Max 思维",
+      "description": "Low：更快更省，适合简单任务。\nMedium：速度和效果平衡，适合日常使用。\nHigh：更认真思考，适合复杂代码和排错。\n勾选后：本工具会按 Max 思维转发；未勾选则使用 Claude 当前默认配置。",
+      "requestOptions": {
+        "anthropic": {
+          "thinking": {
+            "type": "enabled"
+          },
+          "output_config": {
+            "effort": "max"
+          }
+        }
+      }
+    }
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/03-kimi.json
+++ b/backend/presets/03-kimi.json
@@ -1,0 +1,14 @@
+{
+  "id": "kimi",
+  "name": "Kimi (月之暗面)",
+  "baseUrl": "https://api.moonshot.cn/anthropic",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "kimi-k2.6",
+    "haiku": "kimi-k2.6",
+    "opus": "kimi-k2.6",
+    "default": "kimi-k2.6"
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/04-kimi-code.json
+++ b/backend/presets/04-kimi-code.json
@@ -1,0 +1,14 @@
+{
+  "id": "kimi-code",
+  "name": "Kimi Code",
+  "baseUrl": "https://api.kimi.com/coding",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "kimi-for-coding",
+    "haiku": "kimi-for-coding",
+    "opus": "kimi-for-coding",
+    "default": "kimi-for-coding"
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/05-xiaomi-mimo-payg.json
+++ b/backend/presets/05-xiaomi-mimo-payg.json
@@ -1,0 +1,29 @@
+{
+  "id": "xiaomi-mimo-payg",
+  "name": "Xiaomi MiMo (Pay for Token)",
+  "baseUrl": "https://api.xiaomimimo.com/anthropic",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "",
+    "haiku": "",
+    "opus": "",
+    "default": "mimo-v2.5-pro"
+  },
+  "modelOptions": {
+    "mimo_1m": {
+      "label": "启用 MiMo 1M 上下文",
+      "description": "用于 Claude Code/长上下文场景。只会把已显式映射到 MiMo Pro 的 Claude 模型入口标记为 1M；Default 不会作为菜单项。",
+      "modelCapabilities": {
+        "mimo-v2.5-pro": {
+          "supports1m": true
+        },
+        "mimo-v2-pro": {
+          "supports1m": true
+        }
+      }
+    }
+  },
+  "modelCapabilities": {},
+  "isBuiltin": true
+}

--- a/backend/presets/06-xiaomi-mimo-token-plan.json
+++ b/backend/presets/06-xiaomi-mimo-token-plan.json
@@ -1,0 +1,44 @@
+{
+  "id": "xiaomi-mimo-token-plan",
+  "name": "Xiaomi MiMo (Token Plan)",
+  "baseUrl": "https://token-plan-cn.xiaomimimo.com/anthropic",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "baseUrlOptions": [
+    {
+      "label": "中国集群",
+      "value": "https://token-plan-cn.xiaomimimo.com/anthropic"
+    },
+    {
+      "label": "新加坡集群",
+      "value": "https://token-plan-sgp.xiaomimimo.com/anthropic"
+    },
+    {
+      "label": "欧洲集群",
+      "value": "https://token-plan-ams.xiaomimimo.com/anthropic"
+    }
+  ],
+  "baseUrlHint": "请使用账号所属地区的 Base URL，若不清楚请访问 https://platform.xiaomimimo.com/console/plan-manage 获取专属Base URL。",
+  "models": {
+    "sonnet": "",
+    "haiku": "",
+    "opus": "",
+    "default": "mimo-v2.5-pro"
+  },
+  "modelOptions": {
+    "mimo_1m": {
+      "label": "启用 MiMo 1M 上下文",
+      "description": "用于 Claude Code/长上下文场景。只会把已显式映射到 MiMo Pro 的 Claude 模型入口标记为 1M；Default 不会作为菜单项。",
+      "modelCapabilities": {
+        "mimo-v2.5-pro": {
+          "supports1m": true
+        },
+        "mimo-v2-pro": {
+          "supports1m": true
+        }
+      }
+    }
+  },
+  "modelCapabilities": {},
+  "isBuiltin": true
+}

--- a/backend/presets/07-zhipu.json
+++ b/backend/presets/07-zhipu.json
@@ -1,0 +1,14 @@
+{
+  "id": "zhipu",
+  "name": "智谱 GLM",
+  "baseUrl": "https://open.bigmodel.cn/api/anthropic",
+  "authScheme": "x-api-key",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "glm-5.1",
+    "haiku": "glm-4.7",
+    "opus": "glm-5.1",
+    "default": "glm-5.1"
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/08-bailian.json
+++ b/backend/presets/08-bailian.json
@@ -1,0 +1,30 @@
+{
+  "id": "bailian",
+  "name": "阿里云百炼",
+  "baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
+  "authScheme": "x-api-key",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "qwen3.6-plus",
+    "haiku": "qwen3.6-flash",
+    "opus": "qwen3.6-max-preview",
+    "default": "qwen3.6-plus"
+  },
+  "modelOptions": {
+    "qwen_1m": {
+      "label": "开启千问 1M 上下文",
+      "description": "阿里云文档确认 qwen3.6-plus / qwen3.6-flash 支持 1M。勾选后会把 1M 能力写入 Claude 桌面版；不勾选则按普通上下文显示。",
+      "modelCapabilities": {
+        "qwen3.6-plus": {
+          "supports1m": true
+        },
+        "qwen3.6-flash": {
+          "supports1m": true
+        }
+      }
+    }
+  },
+  "modelCapabilities": {},
+  "requestOptions": {},
+  "isBuiltin": true
+}

--- a/backend/presets/09-bailian-token-plan.json
+++ b/backend/presets/09-bailian-token-plan.json
@@ -1,0 +1,14 @@
+{
+  "id": "bailian-token-plan",
+  "name": "阿里云百炼 (Token Plan)",
+  "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+  "authScheme": "bearer",
+  "apiFormat": "anthropic",
+  "models": {
+    "sonnet": "",
+    "haiku": "",
+    "opus": "",
+    "default": "qwen3.6-plus"
+  },
+  "isBuiltin": true
+}

--- a/backend/presets/schema.json
+++ b/backend/presets/schema.json
@@ -1,0 +1,170 @@
+{
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "baseUrl",
+    "authScheme",
+    "apiFormat",
+    "models",
+    "isBuiltin"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "baseUrl": {
+      "type": "string"
+    },
+    "authScheme": {
+      "type": "string",
+      "enum": [
+        "bearer",
+        "x-api-key",
+        "none"
+      ]
+    },
+    "apiFormat": {
+      "type": "string",
+      "enum": [
+        "anthropic",
+        "claude",
+        "messages",
+        "openai",
+        "openai_chat",
+        "chat_completions"
+      ]
+    },
+    "models": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "baseUrlHint": {
+      "type": "string"
+    },
+    "baseUrlOptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "label",
+          "value"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "extraHeaders": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "modelCapabilities": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "supports1m": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "modelOptions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "label",
+          "description"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "models": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "modelCapabilities": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "supports1m": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "requestOptions": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "requestOptionPresets": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "label",
+          "description",
+          "requestOptions"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "requestOptions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "isBuiltin": {
+      "type": "boolean",
+      "enum": [
+        true
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/build.spec
+++ b/build.spec
@@ -52,10 +52,12 @@ a = Analysis(
     binaries=[],
     datas=[
         (str(FRONTEND), "frontend"),
+        (str(ROOT / "backend" / "presets"), "backend/presets"),
         (str(ROOT / "LICENSE.txt"), "."),
     ] + WEBVIEW_DATAS + PYSTRAY_DATAS,
     hiddenimports=[
         "backend", "backend.main", "backend.config",
+        "backend.preset_loader",
         "backend.api_adapters", "backend.ccswitch_import", "backend.model_alias",
         "backend.provider_tools", "backend.registry", "backend.proxy", "backend.update", "backend.i18n",
         "socksio",

--- a/macos/build-macos.spec
+++ b/macos/build-macos.spec
@@ -67,6 +67,7 @@ a = Analysis(
     binaries=[],
     datas=[
         (str(FRONTEND), "frontend"),
+        (str(ROOT / "backend" / "presets"), "backend/presets"),
         (str(ROOT / "LICENSE.txt"), "."),
     ] + WEBVIEW_DATAS + PYSTRAY_DATAS,
     hiddenimports=[
@@ -75,6 +76,7 @@ a = Analysis(
         "backend.api_adapters",
         "backend.ccswitch_import",
         "backend.config",
+        "backend.preset_loader",
         "backend.model_alias",
         "backend.provider_tools",
         "backend.registry",

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -35,6 +35,7 @@ from main import (
 from backend import config as cfg
 from backend import ccswitch_import
 from backend import main as backend_main
+from backend import preset_loader
 from backend import provider_tools
 from backend import registry
 from backend import update as updater
@@ -224,6 +225,68 @@ class ProviderConfigTests(unittest.TestCase):
         self.assertEqual(deepseek_max["requestOptions"]["anthropic"]["thinking"]["type"], "enabled")
         self.assertIn("Low：更快更省", deepseek_max["description"])
         self.assertIn("未勾选则使用 Claude 当前默认配置", deepseek_max["description"])
+
+    def test_builtin_preset_loader_skips_invalid_schema_entries(self):
+        schema = {
+            "type": "object",
+            "required": ["id", "name", "baseUrl", "authScheme", "apiFormat", "models", "isBuiltin"],
+            "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "name": {"type": "string", "minLength": 1},
+                "baseUrl": {"type": "string"},
+                "authScheme": {"type": "string"},
+                "apiFormat": {"type": "string"},
+                "models": {
+                    "type": "object",
+                    "required": ["default"],
+                    "additionalProperties": {"type": "string"},
+                },
+                "isBuiltin": {"type": "boolean", "enum": [True]},
+            },
+            "additionalProperties": True,
+        }
+        valid_preset = {
+            "id": "valid",
+            "name": "Valid Preset",
+            "baseUrl": "https://example.com/anthropic",
+            "authScheme": "bearer",
+            "apiFormat": "anthropic",
+            "models": {"default": "model-a", "sonnet": "model-a"},
+            "isBuiltin": True,
+        }
+        invalid_preset = {
+            "id": "invalid",
+            "baseUrl": "https://example.com/anthropic",
+            "authScheme": "bearer",
+            "apiFormat": "anthropic",
+            "models": {"default": "model-b"},
+            "isBuiltin": True,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            presets_dir = Path(temp_dir)
+            (presets_dir / "schema.json").write_text(json.dumps(schema, ensure_ascii=False, indent=2), encoding="utf-8")
+            (presets_dir / "01-valid.json").write_text(json.dumps(valid_preset, ensure_ascii=False, indent=2), encoding="utf-8")
+            (presets_dir / "02-invalid.json").write_text(json.dumps(invalid_preset, ensure_ascii=False, indent=2), encoding="utf-8")
+
+            with patch.object(preset_loader, "PRESETS_DIR", presets_dir), patch.object(preset_loader, "PRESET_SCHEMA_FILE", presets_dir / "schema.json"):
+                with self.assertLogs("backend.preset_loader", level="WARNING") as logs:
+                    presets = cfg.get_presets()
+
+        self.assertEqual([preset["id"] for preset in presets], ["valid"])
+        self.assertIn("02-invalid.json", "\n".join(logs.output))
+        self.assertIn("missing required field", "\n".join(logs.output))
+
+    def test_presets_api_returns_file_backed_presets(self):
+        client = TestClient(create_admin_app())
+
+        response = client.get("/api/presets", headers=admin_headers())
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["presets"])
+        self.assertEqual(payload["presets"][0]["id"], "deepseek")
+        self.assertIn("bailian", {preset["id"] for preset in payload["presets"]})
 
     def test_registry_inference_models_mark_deepseek_1m(self):
         provider = {
@@ -2523,6 +2586,15 @@ class ReleaseManifestTests(unittest.TestCase):
         self.assertIn("httpx[socks]", requirements)
         self.assertIn('"socksio"', build_spec)
         self.assertIn('"socksio"', macos_spec)
+
+    def test_build_metadata_includes_builtin_preset_data_files(self):
+        build_spec = (self.root / "build.spec").read_text(encoding="utf-8")
+        macos_spec = (self.root / "macos" / "build-macos.spec").read_text(encoding="utf-8")
+
+        self.assertIn('ROOT / "backend" / "presets"', build_spec)
+        self.assertIn('"backend/presets"', build_spec)
+        self.assertIn('ROOT / "backend" / "presets"', macos_spec)
+        self.assertIn('"backend/presets"', macos_spec)
 
     def _run_manifest(self):
         script = self.root / "scripts" / "New-ReleaseManifest.ps1"


### PR DESCRIPTION
## Detail

- move builtin provider presets from `backend/config.py` into `backend/presets/*.json`
- add `backend/preset_loader.py` and `backend/presets/schema.json` to load and validate preset data
- keep `cfg.get_presets()` output shape stable so existing API and frontend consumers remain compatible
- update `build.spec` and `macos/build-macos.spec` so packaged builds include preset data files
- add regression tests for file-backed preset loading, schema validation skip behavior, `/api/presets`, and packaging

## Why

Builtin provider presets had grown into a large hardcoded constant inside `backend/config.py`, which mixed runtime logic with product data. Moving presets into data files reduces maintenance cost, makes schema validation possible, and prepares the codebase for future provider and capability expansion.