### PR TITLE
update & fix(runtime): isolate dev config , clarify upstream proxy failures and improve startup diagnostics

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -10,9 +10,18 @@ from typing import Optional
 
 from backend.model_alias import model_mappings_with_legacy_aliases, normalize_model_mappings
 
-CONFIG_DIR = os.path.expanduser("~/.cc-desktop-switch")
-CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
-BACKUP_DIR = os.path.join(CONFIG_DIR, "backups")
+
+def _resolve_config_paths() -> tuple[str, str, str]:
+    override = os.environ.get("CCDS_CONFIG_DIR", "").strip()
+    config_dir = os.path.abspath(os.path.expanduser(override or "~/.cc-desktop-switch"))
+    return (
+        config_dir,
+        os.path.join(config_dir, "config.json"),
+        os.path.join(config_dir, "backups"),
+    )
+
+
+CONFIG_DIR, CONFIG_FILE, BACKUP_DIR = _resolve_config_paths()
 DEFAULT_UPDATE_URL = "https://github.com/lonr-6/cc-desktop-switch/releases/latest/download/latest.json"
 
 DEFAULT_CONFIG = {

--- a/backend/proxy.py
+++ b/backend/proxy.py
@@ -406,6 +406,15 @@ def _proxy_log_value(proxy: str) -> str:
     return _redact_sensitive_text(proxy, 300)
 
 
+def _connection_error_message(proxy: Optional[str], message: str) -> str:
+    if proxy:
+        return (
+            f"通过上游代理 {_proxy_log_value(proxy)} 连接上游 API 失败: {message}。"
+            "请确认代理地址可用，或先关闭“上游代理”。"
+        )
+    return f"连接上游 API 失败: {message}。请检查网络连接和 API 地址是否正确。"
+
+
 def _stream_content_type_compatible(response: httpx.Response) -> bool:
     content_type = _content_type(response)
     if not content_type:
@@ -590,11 +599,12 @@ async def forward_request(
                     "message": _socks_dependency_error_message(),
                 }
             }
+        proxy = _get_http_proxy()
         log_buffer.add("ERROR", f"请求失败: {message}")
         return {
             "error": {
                 "type": "connection_error",
-                "message": f"连接上游 API 失败: {message}。请检查网络连接和 API 地址是否正确。",
+                "message": _connection_error_message(proxy, message),
             }
         }
 
@@ -764,12 +774,13 @@ async def forward_request_stream(
             }
             yield f"event: error\ndata: {json.dumps(error_event, ensure_ascii=False)}\n\n"
             return
+        proxy = _get_http_proxy()
         log_buffer.add("ERROR", f"流式请求失败: {message}")
         error_event = {
             "type": "error",
             "error": {
                 "type": "connection_error",
-                "message": f"连接上游 API 失败: {message}。请检查网络连接和 API 地址是否正确。",
+                "message": _connection_error_message(proxy, message),
             },
         }
         yield f"event: error\ndata: {json.dumps(error_event, ensure_ascii=False)}\n\n"

--- a/main.py
+++ b/main.py
@@ -720,7 +720,11 @@ def main():
     auto_start_proxy = settings.get("autoStart", False)
 
     if not acquire_single_instance_lock():
-        if not request_existing_instance_activate(admin_port):
+        safe_print("CC Desktop Switch 已经在运行，正在尝试唤起现有窗口...")
+        if request_existing_instance_activate(admin_port):
+            safe_print("已唤起现有实例；请查看任务栏或系统托盘。")
+        else:
+            safe_print("未能唤起现有实例；请从任务栏或系统托盘打开已有窗口。")
             show_message_box(
                 APP_NAME,
                 "CC Desktop Switch 已经在运行。\n\n请从任务栏或系统托盘打开已有窗口。",

--- a/start.bat
+++ b/start.bat
@@ -7,6 +7,12 @@ echo ========================================
 
 cd /d "%~dp0"
 
+if not defined CCDS_CONFIG_DIR (
+    set "CCDS_CONFIG_DIR=%~dp0.tmp\dev-config"
+    echo [信息] 开发启动默认使用独立配置目录:
+    echo        %CCDS_CONFIG_DIR%
+)
+
 REM 检查 Python
 python --version >nul 2>&1
 if %errorlevel% neq 0 (

--- a/start.bat
+++ b/start.bat
@@ -1,7 +1,9 @@
 @echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
 title CC Desktop Switch
 echo ========================================
-echo    CC Desktop Switch v1.0.17
+echo    CC Desktop Switch v1.0.24
 echo    正在启动管理后台...
 echo ========================================
 
@@ -10,7 +12,7 @@ cd /d "%~dp0"
 if not defined CCDS_CONFIG_DIR (
     set "CCDS_CONFIG_DIR=%~dp0.tmp\dev-config"
     echo [信息] 开发启动默认使用独立配置目录:
-    echo        %CCDS_CONFIG_DIR%
+    echo        !CCDS_CONFIG_DIR!
 )
 
 REM 检查 Python

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -1,6 +1,7 @@
 import copy
 import asyncio
 import base64
+import importlib
 import json
 import os
 import re
@@ -176,6 +177,22 @@ class ProviderConfigTests(unittest.TestCase):
         self.assertEqual(first["id"], "same")
         self.assertNotEqual(second["id"], "same")
         self.assertEqual(len({p["id"] for p in cfg.get_providers()}), 2)
+
+    def test_config_dir_can_be_overridden_by_env(self):
+        override_dir = os.path.join(self.temp_dir.name, "nested", "..", "override-config")
+
+        with patch.dict(os.environ, {"CCDS_CONFIG_DIR": override_dir}, clear=False):
+            importlib.reload(cfg)
+
+        expected_dir = os.path.abspath(os.path.join(self.temp_dir.name, "override-config"))
+        self.assertEqual(cfg.CONFIG_DIR, expected_dir)
+        self.assertEqual(cfg.CONFIG_FILE, os.path.join(expected_dir, "config.json"))
+        self.assertEqual(cfg.BACKUP_DIR, os.path.join(expected_dir, "backups"))
+
+        cfg.CONFIG_DIR = self.temp_dir.name
+        cfg.CONFIG_FILE = os.path.join(self.temp_dir.name, "config.json")
+        cfg.BACKUP_DIR = os.path.join(self.temp_dir.name, "backups")
+        cfg.save_config(copy.deepcopy(cfg.DEFAULT_CONFIG))
 
     def test_builtin_presets_include_expected_provider_urls(self):
         presets = {preset["id"]: preset for preset in cfg.get_presets()}
@@ -3164,6 +3181,45 @@ class ProxyConversionTests(unittest.TestCase):
 
         self.assertEqual(result["error"]["type"], "socks_proxy_dependency_missing")
         self.assertIn("SOCKS", result["error"]["message"])
+
+    def test_connect_error_mentions_configured_upstream_proxy(self):
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, *args, **kwargs):
+                raise httpx.ConnectError("All connection attempts failed")
+
+        provider = {
+            "name": "DeepSeek",
+            "baseUrl": "https://api.deepseek.com/anthropic",
+            "apiKey": "provider-key",
+            "authScheme": "bearer",
+            "apiFormat": "anthropic",
+        }
+        body = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 8,
+        }
+
+        with patch("backend.proxy.get_settings", return_value={
+            "upstreamProxyEnabled": True,
+            "upstreamProxy": "socks5://proxy-user:proxy-pass@127.0.0.1:1080",
+        }):
+            with patch("backend.proxy.httpx.AsyncClient", FakeClient):
+                result = asyncio.run(forward_request(body, provider, "req-connect-proxy"))
+
+        self.assertEqual(result["error"]["type"], "connection_error")
+        self.assertIn("通过上游代理", result["error"]["message"])
+        self.assertIn("127.0.0.1:1080", result["error"]["message"])
+        self.assertNotIn("proxy-pass", result["error"]["message"])
 
     def test_socks_proxy_dependency_error_streams_as_error_event(self):
         class FakeClient:

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -1,5 +1,6 @@
 import copy
 import asyncio
+import argparse
 import base64
 import importlib
 import json
@@ -33,6 +34,7 @@ from main import (
     request_existing_instance_activate,
     run_browser_mode,
 )
+import main as app_main
 from backend import config as cfg
 from backend import ccswitch_import
 from backend import main as backend_main
@@ -2725,6 +2727,26 @@ class SingleInstanceStartupTests(unittest.TestCase):
         self.assertIn(admin_public_url(18081), printed)
         self.assertNotIn(admin_ui_url(18081), printed)
         self.assertNotIn(get_admin_token(), printed)
+
+    def test_main_reports_existing_instance_activation_in_console(self):
+        messages = []
+
+        def fake_safe_print(message):
+            messages.append(str(message))
+
+        with patch("main.parse_args", return_value=argparse.Namespace(browser=False, server_only=False, port=None)):
+            with patch("main.cfg.ensure_config_dir"):
+                with patch("main.cfg.get_settings", return_value={"adminPort": 18081, "proxyPort": 18080, "autoStart": False}):
+                    with patch("main.acquire_single_instance_lock", return_value=False):
+                        with patch("main.request_existing_instance_activate", return_value=True):
+                            with patch("main.safe_print", fake_safe_print):
+                                with patch("main.show_message_box") as message_box:
+                                    app_main.main()
+
+        printed = "\n".join(messages)
+        self.assertIn("已经在运行，正在尝试唤起现有窗口", printed)
+        self.assertIn("已唤起现有实例", printed)
+        message_box.assert_not_called()
 
 
 class ProxyConversionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add `CCDS_CONFIG_DIR` support so runtime config can be isolated from the default user profile directory
- make `start.bat` default to a repo-local `.tmp/dev-config` directory for source-based development runs
- improve `start.bat` console behavior with UTF-8 output, correct delayed expansion, and the current app version banner
- improve upstream connection errors so configured proxy failures are reported explicitly and with redacted credentials
- print a clear console message when `main.py` detects that an existing CC Desktop Switch instance is already running
- add regression tests for config directory override, proxy-aware `ConnectError` messaging, and existing-instance console output

## Problem and Why

The source/dev runtime and the installed runtime both default to `~/.cc-desktop-switch`, so local development or debugging can unintentionally mutate the same config used by the actively running desktop instance.

In practice, this showed up as repeated `ConnectError: All connection attempts failed` responses while the app was configured to use a local SOCKS proxy that was no longer listening.

It also made repeated `start.bat` launches look like silent failures when an instance was already running, because the single-instance path returned without a clear console explanation.

## What changed

- `backend/config.py`
	- resolve config paths through `CCDS_CONFIG_DIR` when provided
- `start.bat`
	- default local development runs to `.tmp/dev-config`
	- enable delayed expansion so the configured dev path is printed correctly
	- switch the batch console to UTF-8 and update the visible banner version
- `main.py`
	- print explicit guidance when startup hits the existing-instance activation path
- `backend/proxy.py`
	- return a clearer proxy-specific connection error message when an upstream proxy is configured
- `tests/test_provider_config_and_proxy.py`
	- cover env-based config path override
	- cover proxy-aware connect error messaging
	- cover existing-instance console messaging