### PR TITLE
feat: add Astraflow env var metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/lonr-6/cc-desktop-switch/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/lonr-6/cc-desktop-switch/total?label=downloads"></a>
 </p>
 
-CC Desktop Switch is a lightweight desktop app for the official Claude Desktop client. It lets you manage third-party Anthropic-compatible API providers such as DeepSeek, Kimi, Zhipu GLM, Alibaba Cloud Bailian, and Xiaomi MiMo, then apply the right Claude Desktop 3P configuration with one click.
+CC Desktop Switch is a lightweight desktop app for the official Claude Desktop client. It lets you manage third-party Anthropic-compatible API providers such as DeepSeek, Kimi, Zhipu GLM, Alibaba Cloud Bailian, Xiaomi MiMo, and Astraflow, then apply the right Claude Desktop 3P configuration with one click.
 
 This project is focused on Claude Desktop on Windows and macOS. It is different from CLI-oriented tools such as `farion1231/cc-switch`: the goal here is to give regular desktop users a simple UI for provider setup, model mapping, health checks, and local gateway compatibility.
 
@@ -51,7 +51,7 @@ Since v1.0.18, Claude Desktop is configured to call the local CC Desktop Switch 
 
 ## What It Does
 
-- Manages DeepSeek, Kimi, Zhipu GLM, Alibaba Cloud Bailian, Xiaomi MiMo, and custom third-party providers.
+- Manages DeepSeek, Kimi, Zhipu GLM, Alibaba Cloud Bailian, Xiaomi MiMo, Astraflow, and custom third-party providers.
 - Applies Claude Desktop third-party inference settings on Windows and macOS.
 - Uses a local gateway to keep model mapping, protocol compatibility, extra headers, and upstream keys under local control.
 - Shows only explicitly mapped Claude-safe model routes in Claude Desktop.

--- a/backend/presets/10-astraflow.json
+++ b/backend/presets/10-astraflow.json
@@ -2,6 +2,17 @@
   "id": "astraflow",
   "name": "Astraflow",
   "baseUrl": "https://api-us-ca.umodelverse.ai/v1",
+  "apiKeyEnv": "ASTRAFLOW_API_KEY",
+  "apiKeyEnvOptions": [
+    {
+      "label": "Global",
+      "value": "ASTRAFLOW_API_KEY"
+    },
+    {
+      "label": "China",
+      "value": "ASTRAFLOW_CN_API_KEY"
+    }
+  ],
   "baseUrlOptions": [
     {
       "label": "Global",

--- a/backend/presets/10-astraflow.json
+++ b/backend/presets/10-astraflow.json
@@ -1,0 +1,25 @@
+{
+  "id": "astraflow",
+  "name": "Astraflow",
+  "baseUrl": "https://api-us-ca.umodelverse.ai/v1",
+  "baseUrlOptions": [
+    {
+      "label": "Global",
+      "value": "https://api-us-ca.umodelverse.ai/v1"
+    },
+    {
+      "label": "China",
+      "value": "https://api.modelverse.cn/v1"
+    }
+  ],
+  "authScheme": "bearer",
+  "apiFormat": "openai",
+  "models": {
+    "sonnet": "",
+    "haiku": "",
+    "opus": "",
+    "default": ""
+  },
+  "requestOptions": {},
+  "isBuiltin": true
+}

--- a/backend/presets/schema.json
+++ b/backend/presets/schema.json
@@ -74,6 +74,30 @@
         "additionalProperties": false
       }
     },
+    "apiKeyEnv": {
+      "type": "string"
+    },
+    "apiKeyEnvOptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "label",
+          "value"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "extraHeaders": {
       "type": "object",
       "additionalProperties": {


### PR DESCRIPTION
## Summary
- Add Astraflow environment variable metadata to the built-in preset
- Allow optional provider preset API key environment variable metadata in the preset schema

## Notes
- Global Astraflow API key env var: `ASTRAFLOW_API_KEY`
- China Astraflow API key env var: `ASTRAFLOW_CN_API_KEY`