### PR TITLE
fix(config): stop legacy model aliases from resurrecting cleared mapping slots

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -325,7 +325,9 @@ def update_provider(provider_id: str, data: dict) -> Optional[dict]:
                 updated["requestOptions"] = p.get("requestOptions", {})
 
             if "models" in data and isinstance(data["models"], dict):
-                merged_models = dict(p.get("models", {}))
+                # load_config() 给 models 注入的旧别名只用于兼容读取；merge 前先
+                # 归一化剥掉它们，否则显式清空的槽位会被旧别名回落重新填上。
+                merged_models = normalize_model_mappings(p.get("models", {}))
                 merged_models.update(data["models"])
                 updated["models"] = normalize_model_mappings(merged_models)
 

--- a/tests/test_provider_config_and_proxy.py
+++ b/tests/test_provider_config_and_proxy.py
@@ -133,6 +133,46 @@ class ProviderConfigTests(unittest.TestCase):
 
         self.assertEqual(updated["apiKey"], "new-key")
 
+    def test_update_provider_clears_model_slots_with_legacy_aliases(self):
+        provider = cfg.add_provider({
+            "name": "DeepSeek",
+            "baseUrl": "https://api.deepseek.com/anthropic",
+            "apiKey": "secret-key",
+            "authScheme": "bearer",
+            "apiFormat": "anthropic",
+            "models": {
+                "default": "deepseek-v4-pro",
+                "opus_4_7": "deepseek-v4-pro",
+                "sonnet_4_6": "deepseek-v4-pro",
+                "sonnet_4_5": "deepseek-v4-pro",
+                "haiku_4_5": "deepseek-v4-flash",
+            },
+        })
+
+        updated = cfg.update_provider(provider["id"], {
+            "name": "DeepSeek",
+            "models": {
+                "default": "deepseek-v4-pro",
+                "opus_4_7": "",
+                "opus_4_6": "",
+                "opus_3": "",
+                "sonnet_4_6": "",
+                "sonnet_4_5": "",
+                "haiku_4_5": "",
+            },
+        })
+
+        self.assertEqual(updated["models"]["opus_4_7"], "")
+        self.assertEqual(updated["models"]["sonnet_4_6"], "")
+        self.assertEqual(updated["models"]["haiku_4_5"], "")
+
+        saved = cfg.get_provider(provider["id"])["models"]
+        self.assertEqual(saved["opus_4_7"], "")
+        self.assertEqual(saved["sonnet_4_6"], "")
+        self.assertEqual(saved["sonnet_4_5"], "")
+        self.assertEqual(saved["haiku_4_5"], "")
+        self.assertEqual(saved["default"], "deepseek-v4-pro")
+
     def test_load_config_accepts_utf8_bom(self):
         config = copy.deepcopy(cfg.DEFAULT_CONFIG)
         config["gatewayApiKey"] = "ccds_gateway_secret123456"


### PR DESCRIPTION
Fixes #53

### What

In the provider edit form, removing an **Opus 4.7 / Sonnet 4.6 / Haiku 4.5** mapping row and saving did not clear the slot: the mapping reappeared immediately and kept being written to Claude Desktop's `inferenceModels`. Slots without a legacy alias (`opus_4_6`, `opus_3`, `sonnet_4_5`) cleared fine.

### Why

`load_config()` injects the legacy four-slot aliases (`sonnet` / `opus` / `haiku`) into every provider's `models` for backward-compatible reads. `update_provider()` used that alias-augmented dict as the merge base for writes, and the frontend only submits the new slot keys — so the stale aliases were never overwritten, and `normalize_model_mappings()`'s `(new key, legacy alias)` fallback resurrected the just-cleared slot.

The fix normalizes the merge base first, keeping read-compat aliases out of the write path:

```python
merged_models = normalize_model_mappings(p.get("models", {}))  # was: dict(p.get("models", {}))
merged_models.update(data["models"])
updated["models"] = normalize_model_mappings(merged_models)
```

Behavior is otherwise unchanged: `normalize_model_mappings` is idempotent and was already applied to the merge result on the same lines; legacy alias keys submitted in the payload itself (older clients) still work because the final normalization keeps its `(new key, legacy alias)` fallback; safe custom `claude-*` routes are preserved as before.

### Tests

- Added `test_update_provider_clears_model_slots_with_legacy_aliases` next to the other `update_provider` tests in `tests/test_provider_config_and_proxy.py`. It fails on `main` (`AssertionError: 'deepseek-v4-pro' != ''`) and passes with this fix.
- Full suite on macOS (Python 3.13): `python -m unittest discover -s tests`

  ```
  Ran 161 tests in 1.060s
  FAILED (errors=2, skipped=2)
  ```

  The 2 errors are the pre-existing Windows-only `SingleInstanceStartupTests.test_windows_single_instance_lock_*` cases (`ctypes.windll` does not exist on macOS); they error identically on `main` without this change (`Ran 160 tests ... FAILED (errors=2, skipped=2)`). No other platform-specific tests were run beyond this suite.
- `test_update_provider_keeps_saved_key_and_extra_headers_when_blank`, which submits legacy alias keys in its payload, still passes.

---

This PR was prepared with AI assistance; the author reproduced the bug locally, reviewed every change, and ran the test suite as reported above.
