### PR TITLE
docs: add security disclosure and contributor policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to CC Desktop Switch
+
+Thank you for helping improve CC Desktop Switch. Contributions are welcome for provider compatibility, local gateway behavior, desktop integration, packaging, documentation, tests, and security hardening.
+
+## Before You Start
+
+- Search existing issues and pull requests to avoid duplicate work.
+- Open an issue before large features, behavior changes, new providers, or architecture changes. Small, well-scoped bug fixes may go directly to a pull request.
+- Keep each pull request focused on one problem. Separate unrelated refactors, dependency upgrades, and formatting changes.
+- Report vulnerabilities through the private process in [SECURITY.md](SECURITY.md), not through a public issue or pull request.
+- Never commit real API keys, gateway keys, cookies, authorization headers, private provider endpoints, user configuration, or unredacted logs.
+
+## Development Setup
+
+Requirements:
+
+- Python 3.11 or newer;
+- Node.js 24 for the same frontend syntax checks used in CI;
+- NSIS when modifying `installer.nsi` or Windows installer behavior.
+
+```bash
+git clone https://github.com/lonr-6/cc-desktop-switch.git
+cd cc-desktop-switch
+python -m pip install -r requirements.txt
+python main.py
+```
+
+To open the browser fallback during development:
+
+```bash
+python main.py --browser
+```
+
+Use a temporary configuration directory when testing credential or migration behavior so normal user settings are not modified:
+
+```bash
+CCDS_CONFIG_DIR=/tmp/ccds-dev python main.py --browser
+```
+
+On PowerShell:
+
+```powershell
+$env:CCDS_CONFIG_DIR = "$env:TEMP\ccds-dev"
+python main.py --browser
+```
+
+## Required Verification
+
+Run the checks that apply to your change before opening a pull request:
+
+```bash
+python -m compileall -q backend main.py tests
+python -m unittest discover -s tests -v
+node --check frontend/js/api.js
+node --check frontend/js/app.js
+node --check frontend/js/i18n.js
+```
+
+Installer changes should also pass:
+
+```bash
+mkdir -p dist/CC-Desktop-Switch
+printf 'syntax-check' > dist/CC-Desktop-Switch/placeholder.txt
+makensis -V2 installer.nsi
+```
+
+GitHub Actions repeats the Python and frontend checks on Ubuntu, Windows, and macOS and compiles the NSIS script on Linux.
+
+## Change-Specific Expectations
+
+### Provider presets and model mappings
+
+- Link to authoritative provider documentation in the issue or pull request.
+- State the API format, base URL, authentication scheme, model IDs, streaming behavior, and any nonstandard headers or request fields.
+- Do not add shared, scraped, trial, or embedded credentials.
+- Preserve explicit model routing; do not silently fall back to an unrelated upstream model.
+
+### Configuration and credentials
+
+- Keep existing configurations backward compatible or include a tested migration.
+- Use atomic writes for files that contain credentials or active settings.
+- Avoid logging secrets, full request headers, or complete configuration objects.
+- Add regression tests for import, export, backup, permissions, and failure cleanup when relevant.
+
+### Local gateway and networking
+
+- Treat all custom URLs, redirects, headers, proxy settings, and upstream responses as untrusted input.
+- Preserve local authentication boundaries for the admin API and model gateway.
+- Use explicit timeouts and bounded error handling.
+- Do not weaken TLS verification or forward credentials to a different host without a documented, reviewed reason.
+
+### Claude Desktop and operating-system integration
+
+- Limit registry, policy, plist, process, and filesystem changes to resources owned by CC Desktop Switch.
+- Preserve unrelated administrator or organization-managed settings.
+- Include rollback, backup, or cleanup behavior for destructive changes.
+- Test platform-specific code on the affected operating system when possible.
+
+### Installers, releases, and dependencies
+
+- Keep release downloads pinned to trusted project-controlled locations.
+- Preserve checksum/signature verification and fail closed on integrity mismatches.
+- Explain why a new dependency is necessary and prefer maintained packages with a narrow permission surface.
+
+## Tests
+
+A bug fix should normally include a test that fails before the fix and passes after it. Tests must not require real provider credentials, modify the user's normal Claude Desktop configuration, depend on paid APIs, or make uncontrolled network requests.
+
+Use temporary directories, mock upstream services, and sanitized fixtures. Cross-platform behavior should avoid assuming POSIX permission bits on Windows.
+
+## AI-Assisted Contributions
+
+AI-assisted contributions are welcome, but the human author remains responsible for every line submitted. Review generated changes, understand their security impact, run the relevant tests, and disclose substantial AI-generated implementation in the pull request description. Do not send repository secrets, user logs, private provider data, or third-party proprietary code to an external model.
+
+## Pull Request Checklist
+
+- [ ] The change solves a clearly described problem and is not a duplicate.
+- [ ] The diff is focused and contains no unrelated generated or formatting churn.
+- [ ] Security and backward-compatibility implications are explained.
+- [ ] Tests cover the changed behavior and pass locally.
+- [ ] Documentation or changelog entries are updated when users will notice the change.
+- [ ] No credentials, private logs, build artifacts, or local configuration are committed.
+- [ ] Provider-specific claims link to an authoritative source.
+
+Maintainers may ask for a smaller scope, additional tests, or a design discussion before merging. This protects user credentials and desktop configuration while keeping reviews practical.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+CC Desktop Switch handles user-supplied provider credentials, writes Claude Desktop configuration, runs an authenticated local gateway, and forwards model traffic to user-selected upstream endpoints. Reports involving credentials, local authorization, configuration import/export, upstream URL handling, headers, installers, updates, or filesystem writes should be treated as security-sensitive.
+
+## Supported Versions
+
+Security fixes are developed against the latest published release and the `main` branch. Before reporting, reproduce the issue on the latest version when doing so is safe and does not risk exposing credentials or third-party data.
+
+## Reporting a Vulnerability
+
+**Do not disclose vulnerability details in a public issue, discussion, pull request, or log attachment.**
+
+1. Use GitHub's private vulnerability reporting flow under **Security → Advisories → Report a vulnerability**.
+2. If that button is unavailable, open a public issue titled `[security] private contact requested` and tag `@lonr-6`, but include no technical details, exploit steps, logs, or secrets. A private channel can then be established.
+
+A useful report includes:
+
+- affected version or commit;
+- operating system and installation type;
+- security impact and required attacker capabilities;
+- minimal, sanitized reproduction steps or proof of concept;
+- whether credentials, files, network services, or Claude Desktop policy were exposed or modified;
+- a proposed remediation, if available.
+
+The maintainer will validate the report, determine affected versions, coordinate a fix and disclosure, and credit the reporter unless anonymity is requested. Public disclosure should wait until a fix or mitigation is available.
+
+## Sensitive Data
+
+Never attach real values for any of the following:
+
+- provider API keys or bearer tokens;
+- the local gateway API key;
+- complete `config.json` files or backups;
+- `Authorization`, `x-api-key`, cookie, or proxy-authentication headers;
+- private upstream URLs containing credentials;
+- signing keys, CI secrets, or unredacted installer logs.
+
+Use placeholders such as `sk-redacted` and remove unrelated personal or provider data. If a secret was exposed, revoke or rotate it before continuing the report.
+
+## Security-Relevant Areas
+
+Examples of in-scope findings include:
+
+- credentials readable by another local user, leaked in logs, or exposed through exports;
+- bypasses of local admin or gateway authentication;
+- server-side request forgery or unsafe redirects through custom provider URLs;
+- request-header injection, credential forwarding to the wrong host, or unsafe proxy behavior;
+- malicious configuration imports, path traversal, unsafe file replacement, or destructive policy writes;
+- installer or updater tampering, signature/hash bypasses, or release supply-chain weaknesses;
+- dependency or third-party contribution changes that introduce code execution or credential access.
+
+Third-party provider outages, model-quality problems, account billing disputes, and behavior caused solely by a provider changing its API are normally support issues rather than vulnerabilities unless CC Desktop Switch creates an additional security impact.
+
+## Safe Testing
+
+Test only with accounts, systems, and credentials you control. Do not access another user's data, disrupt public services, retain exposed secrets, or use the project to scan unrelated networks. Stop testing once the impact is demonstrated and report the smallest reproducible case.
+
+## Release Integrity
+
+Official release assets may include SHA-256 checksum files, signatures, and the corresponding public key. Verify downloads before installation, especially when obtained through mirrors or third-party redistribution. Report any mismatch through the private process above.


### PR DESCRIPTION
Superseded by #60. Release PR #57 advanced the protected `main` branch immediately after this PR was opened, so the same two documentation changes were rebuilt from the current main branch rather than force-pushing or adding an opaque merge commit.