### PR TITLE
fix(installer): wait for previous uninstaller during upgrades

### DIFF
--- a/docs/release-notes-v1.0.26.md
+++ b/docs/release-notes-v1.0.26.md
@@ -8,6 +8,7 @@ This patch release hardens provider editing, upstream diagnostics, uninstall cle
 - Tightened DeepSeek Max compatibility detection. Authentication, URL, model, context-length, and unrelated parameter errors now keep their original upstream diagnosis instead of being mislabeled as “Max is unsupported.”
 - Fixed lowercase and canonical OpenAI-compatible preset metadata so presets are routed through the existing API-format normalizer.
 - On Windows, a normal uninstall now removes only Claude Desktop policy values marked with `ccds_managed=true`. Silent in-place upgrades preserve the active provider configuration through `/UPGRADE`.
+- Fixed a Windows in-place upgrade race by running the old NSIS uninstaller synchronously before the replacement installer writes files and uninstall metadata.
 - Added Ubuntu, Windows, and macOS test coverage, frontend JavaScript syntax checks, and NSIS installer compilation.
 - Updated GitHub Actions to the current Node 24 action generations and documented the boundaries for Claude account features and GitHub Copilot BYOK.
 
@@ -23,6 +24,7 @@ No provider migration is required. After upgrading, re-apply the active provider
 - 收紧 DeepSeek Max 兼容错误判断。鉴权、URL、模型、上下文长度和其他参数错误会保留真实上游诊断，不再被误报为“模型不支持 Max”。
 - 修复小写及规范 OpenAI 兼容预设元数据的处理，统一交给现有 API 格式归一化逻辑。
 - Windows 正常卸载时只清理由 `ccds_managed=true` 标记、确由 CCDS 写入的 Claude Desktop 策略值；静默覆盖升级通过 `/UPGRADE` 保留当前 provider 配置。
+- 修复 Windows 覆盖升级竞态：旧 NSIS 卸载器完成同步清理后，新安装器才写入替换文件和卸载信息。
 - 新增 Ubuntu、Windows、macOS 三平台测试、前端 JavaScript 语法检查和 NSIS 安装器编译。
 - GitHub Actions 升级到当前 Node 24 action 代际，并补充 Claude 账号功能和 GitHub Copilot BYOK 的产品边界说明。
 

--- a/installer.nsi
+++ b/installer.nsi
@@ -64,7 +64,12 @@ Function .onInit
 
     ${If} $R0 != ""
         DetailPrint "Existing version detected. The installer will uninstall it first."
-        ExecWait '"$R0" /S /UPGRADE'
+        ; _?= keeps the old NSIS uninstaller in place, so ExecWait really waits
+        ; for cleanup to finish before this installer writes the replacement.
+        ; It must be the final, unquoted command-line parameter.
+        ExecWait '"$R0" /S /UPGRADE _?=$R1'
+        Delete "$R0"
+        RMDir "$R1"
     ${EndIf}
 FunctionEnd
 

--- a/tests/test_maintenance_regressions.py
+++ b/tests/test_maintenance_regressions.py
@@ -37,7 +37,17 @@ class FrontendPresetFormatTests(unittest.TestCase):
 class InstallerCleanupTests(unittest.TestCase):
     def test_upgrade_keeps_policy_and_real_uninstall_clears_only_ccds_values(self):
         source = (ROOT / "installer.nsi").read_text(encoding="utf-8")
-        self.assertIn("/S /UPGRADE", source)
+        upgrade_lines = [
+            line.strip()
+            for line in source.splitlines()
+            if line.strip().startswith("ExecWait") and "/UPGRADE" in line
+        ]
+        self.assertEqual(
+            upgrade_lines,
+            ["ExecWait '\"$R0\" /S /UPGRADE _?=$R1'"],
+        )
+        self.assertIn('Delete "$R0"', source)
+        self.assertIn('RMDir "$R1"', source)
         self.assertIn('${GetOptions} "$R0" "/UPGRADE" $R1', source)
         self.assertIn('ReadRegStr $0 HKCU "${CLAUDE_POLICY_KEY}" "ccds_managed"', source)
         self.assertIn('StrCmp $0 "true" 0 done_clear_policy', source)


### PR DESCRIPTION
## Problem

The v1.0.26 release dry-run exposed a real Windows in-place upgrade race. The installer launched the previous NSIS uninstaller with `ExecWait`, but without the uninstaller-specific `_?=` option. NSIS therefore copied the uninstaller to a temporary directory; the launcher returned before the temporary cleanup process finished, allowing the replacement installer to write files and uninstall metadata that the old cleanup process could subsequently remove.

## Fix

- Invoke the previous uninstaller as `"$R0" /S /UPGRADE _?=$R1`, with `_?=` as the final unquoted parameter, so `ExecWait` blocks until old-version cleanup completes.
- Remove the old in-place uninstaller and now-empty directory after the synchronous cleanup.
- Add regression coverage requiring the exact synchronous upgrade command.
- Add the fix to the v1.0.26 release notes.

## Validation plan

After normal CI and NSIS compilation pass, the release assets will be rebuilt and revalidated through:

- first silent installation;
- same-version silent in-place upgrade;
- installed executable `/api/ready` smoke test;
- real silent uninstall;
- preservation of unrelated Claude policy values while CCDS-managed values are removed.