### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -153,8 +153,8 @@ GitHub Copilot のサブスクリプションは、CC Desktop Switch の provide
 
 ## Star History
 
-<a href="https://www.star-history.com/#lonr-6/cc-desktop-switch&Date">
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lonr-6/cc-desktop-switch&type=Date">
+<a href="https://star-history.dera.page/#lonr-6/cc-desktop-switch&Date">
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lonr-6/cc-desktop-switch&type=Date">
 </a>
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ GitHub Copilot subscriptions are not directly supported as a provider API in CC 
 
 ## Star History
 
-<a href="https://www.star-history.com/#lonr-6/cc-desktop-switch&Date">
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lonr-6/cc-desktop-switch&type=Date">
+<a href="https://star-history.dera.page/#lonr-6/cc-desktop-switch&Date">
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lonr-6/cc-desktop-switch&type=Date">
 </a>
 
 ## Tech Stack

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,8 +163,8 @@ CC Desktop Switch 不直接支持把 GitHub Copilot 订阅账号当作 provider 
 
 ## Star History
 
-<a href="https://www.star-history.com/#lonr-6/cc-desktop-switch&Date">
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lonr-6/cc-desktop-switch&type=Date">
+<a href="https://star-history.dera.page/#lonr-6/cc-desktop-switch&Date">
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lonr-6/cc-desktop-switch&type=Date">
 </a>
 
 ## 技术栈


### PR DESCRIPTION
The star history chart in the READMEs is currently broken and no longer renders due to GitHub stargazer API restrictions. This switches the chart to the maintained star-history.dera.page service, which needs no API token, so the chart displays correctly again for readers of all three README versions.